### PR TITLE
Divide-by-Zero Fix

### DIFF
--- a/1.12/src/main/java/com/rwtema/extrautils2/modcompat/XUTConTextureMagicWood.java
+++ b/1.12/src/main/java/com/rwtema/extrautils2/modcompat/XUTConTextureMagicWood.java
@@ -86,6 +86,9 @@ public class XUTConTextureMagicWood extends XUTConTextureBase {
 			}
 		}
 
+    if(div == 0)
+      div = 1;
+
 		mean = ((mean / div) * 2) / 4;
 
 


### PR DESCRIPTION
We had an issue where the game would crash when using the JSTR resource pack. We found the divide-by-zero, but I haven't read through the rest of the code to ensure that this fix is the correct one.

Thank you for your work, and happy modding!