### PR TITLE
Use stacklimitoverride if it is set in addTooltip

### DIFF
--- a/1.10.2/src/main/java/com/rwtema/extrautils2/transfernodes/Upgrade.java
+++ b/1.10.2/src/main/java/com/rwtema/extrautils2/transfernodes/Upgrade.java
@@ -29,7 +29,7 @@ public enum Upgrade {
 		Upgrade upgrade = item.getUpgrade(stack);
 		if (upgrade != null) {
 			int stackSize = StackHelper.getStacksize(stack);
-			int maxLevel = stacklimitoverride != -1 ? upgrade.maxLevel : stacklimitoverride;
+			int maxLevel = stacklimitoverride == -1 ? upgrade.maxLevel : stacklimitoverride;
 			tooltip.add(Lang.translateArgs("Max Upgrades: %s", maxLevel));
 			if (upgrade.power > 0) {
 				if (maxLevel == 1) {


### PR DESCRIPTION
Fixes the issue with stacklimitoverride being ignored in addTooltip, which causes all tiers of speed upgrades to show 64 as max stack size in the tool tip (instead of 4, 16 or 64).