### PR TITLE
Use "age" instead of "growth"

### DIFF
--- a/1.10.2/src/main/java/com/rwtema/extrautils2/blocks/BlockEnderLilly.java
+++ b/1.10.2/src/main/java/com/rwtema/extrautils2/blocks/BlockEnderLilly.java
@@ -41,7 +41,7 @@ import java.util.Random;
 
 public class BlockEnderLilly extends XUBlockStatic implements IPlantable, IGrowable {
 	public static final EnumPlantType ender = EnumPlantType.getPlantType("ender");
-	public static final PropertyInteger GROWTH_STATE = PropertyInteger.create("growth", 0, 7);
+	public static final PropertyInteger GROWTH_STATE = PropertyInteger.create("age", 0, 7);
 	public static final HashSet<IBlockState> end_stone_states = Sets.newHashSet(Blocks.END_STONE.getBlockState().getValidStates());
 	public static final IMetaProperty<Boolean> READY_TO_GROW = new IMetaProperty.Wrap<Boolean>(PropertyBool.create("ready_to_grow"), false) {
 		@Override

--- a/1.10.2/src/main/java/com/rwtema/extrautils2/blocks/BlockRedOrchid.java
+++ b/1.10.2/src/main/java/com/rwtema/extrautils2/blocks/BlockRedOrchid.java
@@ -37,7 +37,7 @@ import java.util.List;
 import java.util.Random;
 
 public class BlockRedOrchid extends XUBlockStatic implements IPlantable, IGrowable {
-	public static final PropertyInteger GROWTH_STATE = PropertyInteger.create("growth", 0, 6);
+	public static final PropertyInteger GROWTH_STATE = PropertyInteger.create("age", 0, 6);
 	static float[] size_w = {1 / 16F, 1 / 16F, 2 / 16F, 3 / 16F, 3 / 16F, 4 / 16F, 5 / 16F};
 	static float[] size_h = {5 / 16F, 8 / 16F, 9 / 16F, 11 / 16F, 12 / 16F, 13 / 16F, 16 / 16F};
 	public final IBlockState FULLY_GROWN_STATE;

--- a/1.10.2/src/main/resources/assets/extrautils2/blockstates/model_locations.txt
+++ b/1.10.2/src/main/resources/assets/extrautils2/blockstates/model_locations.txt
@@ -12,14 +12,14 @@ models/item/soundmuffler.json
 # Ender Lilly
 blockstates/enderlilly.json
 variants={
-	growth=2
-	growth=3
-	growth=4
-	growth=5
-	growth=0
-	growth=1
-	growth=6
-	growth=7
+	age=2
+	age=3
+	age=4
+	age=5
+	age=0
+	age=1
+	age=6
+	age=7
 }
 
 models/item/enderlilly.json
@@ -159,13 +159,13 @@ models/item/compressednetherrack.json
 # Red Orchid
 blockstates/redorchid.json
 variants={
-	growth=2
-	growth=3
-	growth=4
-	growth=5
-	growth=0
-	growth=1
-	growth=6
+	age=2
+	age=3
+	age=4
+	age=5
+	age=0
+	age=1
+	age=6
 }
 
 models/item/redorchid.json


### PR DESCRIPTION
Basically every other crop uses "age" instead of "growth". If we use it too, then a lot of cross-mod compat that checks the crop's age will "just work". This is not a breaking change, since state is really saved as metadata.